### PR TITLE
10712: Allow horizontal rules in rich-text from Contentful to be rendered

### DIFF
--- a/bedrock/contentful/templatetags/helpers.py
+++ b/bedrock/contentful/templatetags/helpers.py
@@ -33,6 +33,7 @@ ALLOWED_TAGS = [
     "strike",
     "strong",
     "ul",
+    "hr",
 ]
 ALLOWED_ATTRS = [
     "alt",


### PR DESCRIPTION
## Description

Contentful's rich-text editor allows `<hr>` to be added, but it was rendering as escaped markup. This is because it wasn't on the appropriate allow-list.

**NB This is a draft PR which will be rebased on master once https://github.com/mozilla/bedrock/pull/10697 has been merged** 

## Issue / Bugzilla link

Resolves Bedrock 10712 https://github.com/mozilla/bedrock/issues/10712

## Screenshots

Before

<img width="809" alt="Screenshot 2021-11-11 at 12 33 22" src="https://user-images.githubusercontent.com/101457/141298757-a94c200a-80a7-470a-8c61-0edf0ab57e6c.png">


After

<img width="764" alt="Screenshot 2021-11-11 at 12 32 46" src="https://user-images.githubusercontent.com/101457/141298780-5208b256-6337-4660-9291-84aa74014622.png">



## Testing


